### PR TITLE
Looky-6189: [FIX] [Android] sometimes WindowMetrics could not be retrieved

### DIFF
--- a/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaContextModule.kt
+++ b/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaContextModule.kt
@@ -1,9 +1,16 @@
 package com.th3rdwave.safeareacontext
 
+import android.util.Log
 import android.view.View
 import android.view.ViewGroup
+import com.facebook.proguard.annotations.DoNotStrip
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.common.MapBuilder
 import com.facebook.react.module.annotations.ReactModule
+import com.facebook.react.uimanager.PixelUtil
 
 @ReactModule(name = SafeAreaContextModule.NAME)
 class SafeAreaContextModule(reactContext: ReactApplicationContext?) :
@@ -12,15 +19,71 @@ class SafeAreaContextModule(reactContext: ReactApplicationContext?) :
     return NAME
   }
 
-  public override fun getTypedExportedConstants(): Map<String, Any?> {
-    return mapOf("initialWindowMetrics" to getInitialWindowMetrics())
+  /**
+   * getConstants is invoked only at initialization,
+   * but DecorView may be not available then
+   */
+  @ReactMethod
+  @DoNotStrip
+  override fun getWindowMetrics(promise: Promise) {
+    Log.d("SafeAreaContext", "getWindowMetrics")
+
+    val decorView = reactApplicationContext.currentActivity?.window?.decorView as ViewGroup?
+    if (decorView == null) {
+      promise.reject("Couldn't measure", "Couldn't find DecorView")
+      return
+    }
+
+    val contentView = decorView.findViewById<View>(android.R.id.content)
+    if (contentView == null) {
+      promise.reject("Couldn't measure", "Couldn't find contentView")
+      return
+    }
+
+    val insets = getSafeAreaInsets(decorView)
+    val frame = getFrame(decorView, contentView)
+
+    if (insets == null || frame == null) {
+      promise.reject("Couldn't measure", "Couldn't measure insets and/or frame")
+      return
+    }
+
+    Log.d("SafeAreaContext", "getWindowMetrics | insets: $insets, frame: $frame")
+
+    val insetsMap = Arguments.createMap().also { out ->
+      out.putDouble("top", PixelUtil.toDIPFromPixel(insets.top).toDouble())
+      out.putDouble("right", PixelUtil.toDIPFromPixel(insets.right).toDouble())
+      out.putDouble("bottom", PixelUtil.toDIPFromPixel(insets.bottom).toDouble())
+      out.putDouble("left", PixelUtil.toDIPFromPixel(insets.left).toDouble())
+    }
+
+    val frameMap = Arguments.createMap().also { out ->
+      out.putDouble("x", PixelUtil.toDIPFromPixel(frame.x).toDouble())
+      out.putDouble("y", PixelUtil.toDIPFromPixel(frame.y).toDouble())
+      out.putDouble("width", PixelUtil.toDIPFromPixel(frame.width).toDouble())
+      out.putDouble("height", PixelUtil.toDIPFromPixel(frame.height).toDouble())
+    }
+
+    val readableMap = Arguments.createMap().also { out ->
+      out.putMap("insets", insetsMap)
+      out.putMap("frame", frameMap)
+    }
+
+    promise.resolve(readableMap)
+  }
+
+  public override fun getTypedExportedConstants(): Map<String, Any> {
+    return MapBuilder.of<String, Any>("initialWindowMetrics", getInitialWindowMetrics())
   }
 
   private fun getInitialWindowMetrics(): Map<String, Any>? {
+    Log.d("SafeAreaContext", "getInitialWindowMetrics")
     val decorView = reactApplicationContext.currentActivity?.window?.decorView as ViewGroup?
+    Log.d("SafeAreaContext", "getInitialWindowMetrics decor view is ${if (decorView == null)"not" else ""} found")
     val contentView = decorView?.findViewById<View>(android.R.id.content) ?: return null
     val insets = getSafeAreaInsets(decorView)
     val frame = getFrame(decorView, contentView)
+    Log.d("SafeAreaContext", "getInitialWindowMetrics | insets: $insets, frame: $frame")
     return if (insets == null || frame == null) {
       null
     } else mapOf("insets" to edgeInsetsToJavaMap(insets), "frame" to rectToJavaMap(frame))

--- a/android/src/paper/java/com/th3rdwave/safeareacontext/NativeSafeAreaContextSpec.java
+++ b/android/src/paper/java/com/th3rdwave/safeareacontext/NativeSafeAreaContextSpec.java
@@ -21,12 +21,19 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.Promise;
+import kotlin.Unit;
 
 public abstract class NativeSafeAreaContextSpec extends ReactContextBaseJavaModule
     implements ReactModuleWithSpec, TurboModule {
   public NativeSafeAreaContextSpec(ReactApplicationContext reactContext) {
     super(reactContext);
   }
+
+  @ReactMethod
+  @DoNotStrip
+  protected abstract Unit getWindowMetrics(Promise promise);
 
   protected abstract Map<String, Object> getTypedExportedConstants();
 

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,1 @@
+export * from './src';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-safe-area-context",
-  "version": "4.10.9",
+  "version": "4.11.0",
   "description": "A flexible way to handle safe area, also works on Android and web.",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-safe-area-context",
-  "version": "4.11.0",
+  "version": "4.11.1",
   "description": "A flexible way to handle safe area, also works on Android and web.",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/src/specs/NativeSafeAreaContext.ts
+++ b/src/specs/NativeSafeAreaContext.ts
@@ -1,23 +1,14 @@
 import { TurboModule, TurboModuleRegistry } from 'react-native';
 import type { Double } from 'react-native/Libraries/Types/CodegenTypes';
 
+interface WindowMetrics {
+  insets: { top: Double; right: Double; bottom: Double; left: Double; }
+  frame: { x: Double; y: Double; width: Double; height: Double; }
+}
+
 export interface Spec extends TurboModule {
-  getConstants: () => {
-    initialWindowMetrics?: {
-      insets: {
-        top: Double;
-        right: Double;
-        bottom: Double;
-        left: Double;
-      };
-      frame: {
-        x: Double;
-        y: Double;
-        width: Double;
-        height: Double;
-      };
-    };
-  };
+  getConstants(): { initialWindowMetrics?: WindowMetrics };
+  getWindowMetrics?(): Promise<null | WindowMetrics>
 }
 
 export default TurboModuleRegistry.get<Spec>('RNCSafeAreaContext');


### PR DESCRIPTION
# Merge with:
- https://github.com/oneclick-llc/look-box/pull/35
- https://github.com/oneclick-llc/mosaica-src/pull/20
- https://github.com/oneclick-llc/rn-core-lite/pull/8
- https://github.com/oneclick-llc/rn-lootbox-src/pull/4
- https://github.com/oneclick-llc/rn-looky/pull/624

[Looky-6189](https://oneclicklife.youtrack.cloud/issue/Looky-6189/LOOKY-3.6.1-Android-Tab-bar-skryt-za-sistemnym-barom-pri-pervom-zapuske-prilozheniya)